### PR TITLE
[AIR-3420] Fix PER IP rate limit scope handling

### DIFF
--- a/pkg/appparts/impl_app.go
+++ b/pkg/appparts/impl_app.go
@@ -249,8 +249,8 @@ func (bp *borrowedPartition) IsLimitExceeded(resource appdef.QName, operation ap
 	return bp.part.limiter.Exceeded(resource, operation, workspace, remoteAddr)
 }
 
-func (bp *borrowedPartition) ResetRateLimit(resource appdef.QName, operation appdef.OperationKind, workspace istructs.WSID) {
-	bp.part.limiter.ResetLimits(resource, operation, workspace)
+func (bp *borrowedPartition) ResetRateLimit(resource appdef.QName, operation appdef.OperationKind, workspace istructs.WSID, remoteAddr string) {
+	bp.part.limiter.ResetLimits(resource, operation, workspace, remoteAddr)
 }
 
 func (bp *borrowedPartition) IsOperationAllowed(ws appdef.IWorkspace, op appdef.OperationKind, res appdef.QName, fld []appdef.FieldName, roles []appdef.QName) (bool, error) {

--- a/pkg/appparts/interface.go
+++ b/pkg/appparts/interface.go
@@ -114,7 +114,7 @@ type IAppPartition interface {
 	IsLimitExceeded(resource appdef.QName, operation appdef.OperationKind, workspace istructs.WSID, remoteAddr string) (exceed bool, limit appdef.QName)
 
 	// Resets rate limit buckets for specified resource, operation and workspace to their default state.
-	ResetRateLimit(resource appdef.QName, operation appdef.OperationKind, workspace istructs.WSID)
+	ResetRateLimit(resource appdef.QName, operation appdef.OperationKind, workspace istructs.WSID, remoteAddr string)
 }
 
 // Async actualizer runner.

--- a/pkg/appparts/internal/limiter/example_test.go
+++ b/pkg/appparts/internal/limiter/example_test.go
@@ -130,7 +130,7 @@ func Example_resetLimits() {
 	fmt.Println(Limiter.Exceeded(cmdName, appdef.OperationKind_Execute, ws, ``))
 	fmt.Println(Limiter.Exceeded(cmdName, appdef.OperationKind_Execute, ws, ``)) // exceeded
 
-	Limiter.ResetLimits(cmdName, appdef.OperationKind_Execute, ws)
+	Limiter.ResetLimits(cmdName, appdef.OperationKind_Execute, ws, ``)
 
 	fmt.Println(Limiter.Exceeded(cmdName, appdef.OperationKind_Execute, ws, ``)) // allowed again
 

--- a/pkg/appparts/internal/limiter/limiter.go
+++ b/pkg/appparts/internal/limiter/limiter.go
@@ -57,7 +57,7 @@ func (l *Limiter) Exceeded(resource appdef.QName, operation appdef.OperationKind
 	return false, appdef.NullQName
 }
 
-func (l *Limiter) ResetLimits(resource appdef.QName, operation appdef.OperationKind, workspace istructs.WSID) {
+func (l *Limiter) ResetLimits(resource appdef.QName, operation appdef.OperationKind, workspace istructs.WSID, remoteAddr string) {
 	limits, ok := l.limits[resource]
 	if !ok {
 		return
@@ -71,6 +71,9 @@ func (l *Limiter) ResetLimits(resource appdef.QName, operation appdef.OperationK
 		}
 		if limit.Rate().Scope(appdef.RateScope_Workspace) {
 			key.Workspace = workspace
+		}
+		if limit.Rate().Scope(appdef.RateScope_IP) {
+			key.RemoteAddr = remoteAddr
 		}
 		if limit.Filter().Option() == appdef.LimitFilterOption_EACH {
 			key.QName = resource

--- a/pkg/bus/types.go
+++ b/pkg/bus/types.go
@@ -20,7 +20,7 @@ type Request struct {
 	Resource string
 	Body     []byte
 	AppQName appdef.AppQName
-	Host     string // used by authenticator to emit Host principal
+	Host     string // client IP address (host only, port stripped) from http.Request.RemoteAddr
 	IsN10N   bool
 
 	// apiV2

--- a/pkg/processors/command/impl.go
+++ b/pkg/processors/command/impl.go
@@ -436,7 +436,7 @@ func checkWSActive(_ context.Context, cmd *cmdWorkpiece) (err error) {
 }
 
 func limitCallRate(_ context.Context, cmd *cmdWorkpiece) (err error) {
-	if exceeded, _ := cmd.appPart.IsLimitExceeded(cmd.cmdQName, appdef.OperationKind_Execute, cmd.cmdMes.WSID(), ""); exceeded {
+	if exceeded, _ := cmd.appPart.IsLimitExceeded(cmd.cmdQName, appdef.OperationKind_Execute, cmd.cmdMes.WSID(), cmd.cmdMes.Host()); exceeded {
 		return coreutils.NewHTTPErrorf(http.StatusTooManyRequests)
 	}
 	return nil

--- a/pkg/processors/query/impl.go
+++ b/pkg/processors/query/impl.go
@@ -189,7 +189,7 @@ func newQueryProcessorPipeline(requestCtx context.Context, authn iauthnz.IAuthen
 	ops := []*pipeline.WiredOperator{
 		operator("borrowAppPart", borrowAppPart),
 		operator("check function call rate", func(ctx context.Context, qw *queryWork) (err error) {
-			if exceeded, _ := qw.appPart.IsLimitExceeded(qw.msg.QName(), appdef.OperationKind_Execute, qw.msg.WSID(), ""); exceeded {
+			if exceeded, _ := qw.appPart.IsLimitExceeded(qw.msg.QName(), appdef.OperationKind_Execute, qw.msg.WSID(), qw.msg.Host()); exceeded {
 				return coreutils.NewSysError(http.StatusTooManyRequests)
 			}
 			return nil
@@ -463,8 +463,8 @@ func newQueryWork(msg IQueryMessage, appParts appparts.IAppPartitions,
 	}
 }
 
-func (qw *queryWork) ResetRateLimit(resource appdef.QName, operation appdef.OperationKind, workspace istructs.WSID) {
-	qw.appPart.ResetRateLimit(resource, operation, workspace)
+func (qw *queryWork) ResetRateLimit(resource appdef.QName, operation appdef.OperationKind, workspace istructs.WSID, remoteAddr string) {
+	qw.appPart.ResetRateLimit(resource, operation, workspace, remoteAddr)
 }
 
 // need for q.sys.EnrichPrincipalToken

--- a/pkg/processors/query2/util.go
+++ b/pkg/processors/query2/util.go
@@ -27,7 +27,7 @@ import (
 )
 
 func queryRateLimitExceeded(ctx context.Context, qw *queryWork) error {
-	if exceeded, _ := qw.appPart.IsLimitExceeded(qw.msg.QName(), appdef.OperationKind_Execute, qw.msg.WSID(), ""); exceeded {
+	if exceeded, _ := qw.appPart.IsLimitExceeded(qw.msg.QName(), appdef.OperationKind_Execute, qw.msg.WSID(), qw.msg.Host()); exceeded {
 		return coreutils.NewSysError(http.StatusTooManyRequests)
 	}
 	return nil
@@ -85,8 +85,8 @@ type queryWork struct {
 
 var _ pipeline.IWorkpiece = (*queryWork)(nil) // ensure that queryWork implements pipeline.IWorkpiece
 
-func (qw *queryWork) ResetRateLimit(resource appdef.QName, operation appdef.OperationKind, workspace istructs.WSID) {
-	qw.appPart.ResetRateLimit(resource, operation, workspace)
+func (qw *queryWork) ResetRateLimit(resource appdef.QName, operation appdef.OperationKind, workspace istructs.WSID, remoteAddr string) {
+	qw.appPart.ResetRateLimit(resource, operation, workspace, remoteAddr)
 }
 
 func (qw *queryWork) Release() {

--- a/pkg/processors/schedulers/impl_test.go
+++ b/pkg/processors/schedulers/impl_test.go
@@ -142,5 +142,5 @@ func (m *mockAppPartition) IsOperationAllowed(_ appdef.IWorkspace, _ appdef.Oper
 func (m *mockAppPartition) IsLimitExceeded(_ appdef.QName, _ appdef.OperationKind, _ istructs.WSID, _ string) (bool, appdef.QName) {
 	panic("not implemented")
 }
-func (m *mockAppPartition) ResetRateLimit(_ appdef.QName, _ appdef.OperationKind, _ istructs.WSID) {
+func (m *mockAppPartition) ResetRateLimit(_ appdef.QName, _ appdef.OperationKind, _ istructs.WSID, _ string) {
 }

--- a/pkg/router/utils.go
+++ b/pkg/router/utils.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"net"
 	"net/http"
 	"net/url"
 	"runtime/debug"
@@ -124,6 +125,7 @@ func createBusRequest(data validatedData, req *http.Request) bus.Request {
 		AppQName: data.appQName,
 		Resource: data.vars[URLPlaceholder_resourceName],
 		Body:     data.body,
+		Host:     remoteIP(req.RemoteAddr),
 	}
 
 	if docIDStr, hasDocID := data.vars[URLPlaceholder_id]; hasDocID {
@@ -157,6 +159,7 @@ func withLogAttribs(ctx context.Context, data validatedData, busRequest bus.Requ
 		logger.LogAttr_VApp:      data.appQName,
 		logger.LogAttr_Extension: extension,
 		logAttrib_Origin:         req.Header.Get(httpu.Origin),
+		"host":                   busRequest.Host, // TODO: eliminate after check what is actually logged in dev cluster
 	})
 }
 
@@ -194,4 +197,12 @@ func apiPathToExtension(apiPath processors.APIPath) string {
 		return "sys._N10N_SubscribeAndWatch"
 	}
 	return strconv.Itoa(int(apiPath))
+}
+
+func remoteIP(remoteAddr string) string {
+	host, _, err := net.SplitHostPort(remoteAddr)
+	if err != nil {
+		return remoteAddr
+	}
+	return host
 }

--- a/pkg/sys/it/impl_rates_test.go
+++ b/pkg/sys/it/impl_rates_test.go
@@ -60,3 +60,30 @@ func TestRates_BasicUsage(t *testing.T) {
 		vit.PostWS(ws, "c.app1pkg.RatedCmd", bodyCmd)
 	}
 }
+
+func TestRates_PerIP(t *testing.T) {
+	vit := it.NewVIT(t, &it.SharedConfig_App1)
+	defer vit.TearDown()
+
+	ws := vit.WS(istructs.AppQName_test1_app1, "test_ws")
+	bodyQry := `{"args":{}, "elements":[{"path":"","fields":["Fld"]}]}`
+	bodyCmd := `{"args":{}}`
+
+	for range 2 {
+		vit.PostWS(ws, "q.app1pkg.IPRatedQry", bodyQry)
+		vit.PostWS(ws, "c.app1pkg.IPRatedCmd", bodyCmd)
+	}
+
+	vit.PostWS(ws, "q.app1pkg.IPRatedQry", bodyQry, httpu.Expect429())
+	vit.PostWS(ws, "c.app1pkg.IPRatedCmd", bodyCmd, httpu.Expect429())
+
+	vit.TimeAdd(time.Minute)
+
+	for range 2 {
+		vit.PostWS(ws, "q.app1pkg.IPRatedQry", bodyQry)
+		vit.PostWS(ws, "c.app1pkg.IPRatedCmd", bodyCmd)
+	}
+
+	vit.PostWS(ws, "q.app1pkg.IPRatedQry", bodyQry, httpu.Expect429())
+	vit.PostWS(ws, "c.app1pkg.IPRatedCmd", bodyCmd, httpu.Expect429())
+}

--- a/pkg/sys/verifier/impl.go
+++ b/pkg/sys/verifier/impl.go
@@ -161,9 +161,9 @@ func provideIVVTExec(itokens itokens.ITokens, asp istructs.IAppStructsProvider) 
 
 		// code ok -> reset per-profile rate limit
 		limitsResetter := args.Workpiece.(interface {
-			ResetRateLimit(appdef.QName, appdef.OperationKind, istructs.WSID)
+			ResetRateLimit(appdef.QName, appdef.OperationKind, istructs.WSID, string)
 		})
-		limitsResetter.ResetRateLimit(QNameQueryIssueVerifiedValueToken, appdef.OperationKind_Execute, args.WSID)
+		limitsResetter.ResetRateLimit(QNameQueryIssueVerifiedValueToken, appdef.OperationKind_Execute, args.WSID, "")
 
 		return callback(&ivvtResult{verifiedValueToken: verifiedValueToken})
 	}

--- a/pkg/vit/schemaTestApp1.vsql
+++ b/pkg/vit/schemaTestApp1.vsql
@@ -804,14 +804,20 @@ ALTERABLE WORKSPACE test_wsWS (
 
 		COMMAND TTLStorageCmd(TTLStorageParams) RETURNS TTLStorageResult WITH Tags=(WorkspaceOwnerFuncTag);
 		QUERY TTLGetQry(TTLGetParams) RETURNS TTLGetResult WITH Tags=(WorkspaceOwnerFuncTag);
+
+		COMMAND IPRatedCmd(RatedCmdParams) WITH Tags =(WorkspaceOwnerFuncTag);
+		QUERY IPRatedQry(RatedQryParams) RETURNS RatedQryResult WITH Tags =(WorkspaceOwnerFuncTag);
 	);
 
 	RATE RatedPerMinute 2 PER MINUTE PER APP PARTITION;
 	RATE RatedPerHour 4 PER HOUR PER WORKSPACE;
+	RATE IPRatedPerMinute 2 PER MINUTE PER IP;
 	LIMIT RatedCmdPerMinute ON COMMAND RatedCmd WITH RATE RatedPerMinute;
 	LIMIT RatedQryPerMinute ON QUERY RatedQry WITH RATE RatedPerMinute;
 	LIMIT RatedCmdPerHour ON COMMAND RatedCmd WITH RATE RatedPerHour;
 	LIMIT RatedQryPerHour ON QUERY RatedQry WITH RATE RatedPerHour;
+	LIMIT IPRatedCmdPerMinute ON COMMAND IPRatedCmd WITH RATE IPRatedPerMinute;
+	LIMIT IPRatedQryPerMinute ON QUERY IPRatedQry WITH RATE IPRatedPerMinute;
 
 	ROLE Updated; -- need for invite tests
 	ROLE SpecialAPITokenRole; -- need to test foreign auth using APIToken

--- a/pkg/vit/shared_cfgs.go
+++ b/pkg/vit/shared_cfgs.go
@@ -92,6 +92,8 @@ var (
 	QNameApp1_WDocCapabilities               = appdef.NewQName(app1PkgName, "Capabilities")
 	QNameCmdRated                            = appdef.NewQName(app1PkgName, "RatedCmd")
 	QNameQryRated                            = appdef.NewQName(app1PkgName, "RatedQry")
+	QNameCmdIPRated                          = appdef.NewQName(app1PkgName, "IPRatedCmd")
+	QNameQryIPRated                          = appdef.NewQName(app1PkgName, "IPRatedQry")
 	QNameODoc1                               = appdef.NewQName(app1PkgName, "odoc1")
 	QNameODoc2                               = appdef.NewQName(app1PkgName, "odoc2")
 	TestSMTPCfg                              = smtp.Cfg{
@@ -236,6 +238,16 @@ func ProvideApp1(apis builtinapps.APIs, cfg *istructsmem.AppConfigType, ep exten
 
 	cfg.Resources.Add(istructsmem.NewCommandFunction(
 		QNameCmdRated,
+		istructsmem.NullCommandExec,
+	))
+
+	cfg.Resources.Add(istructsmem.NewQueryFunction(
+		QNameQryIPRated,
+		istructsmem.NullQueryExec,
+	))
+
+	cfg.Resources.Add(istructsmem.NewCommandFunction(
+		QNameCmdIPRated,
 		istructsmem.NullCommandExec,
 	))
 

--- a/uspecs/changes/2603271541-per-ip-rate-limit-scope/change.md
+++ b/uspecs/changes/2603271541-per-ip-rate-limit-scope/change.md
@@ -1,0 +1,24 @@
+---
+registered_at: 2026-03-27T15:41:48Z
+change_id: 2603271541-per-ip-rate-limit-scope
+baseline: ebd38ec250cc672fa7f06591c39c47b859e00d2c
+issue_url: https://untill.atlassian.net/browse/AIR-3420
+---
+
+# Change request: Use PER IP rate limit scope
+
+## Why
+
+The limiter's `ResetLimits` method does not account for `RateScope_IP` when building bucket keys, while the `Exceeded` method does. This inconsistency means that IP-scoped rate limits are never properly reset, causing incorrect rate limiting behavior after a reset is requested. The same problem exists with `IAppPartition.IsLimitExceeded` — both command and query processors pass an empty string as `remoteAddr`, so IP-scoped rate limits are never properly enforced.
+
+See [issue.md](issue.md) for details.
+
+## What
+
+Fix IP-scoped rate limit handling across the codebase:
+
+- Add `remoteAddr` parameter to `Limiter.ResetLimits` and `IAppPartition.ResetRateLimit` so they can build IP-scoped bucket keys
+- Set `key.RemoteAddr` when the limit rate has `RateScope_IP` in `ResetLimits`, matching the logic already present in `Exceeded`
+- Pass actual `remoteAddr` values (instead of empty strings) in command processor (`limitCallRate`) and query processor (`check function call rate`) when calling `IsLimitExceeded`
+- Update all callers of `ResetRateLimit` to pass the remote address
+- Source `remoteAddr` from `http.Request.RemoteAddr` at the router level, stripping the port via `net.SplitHostPort` (rate limiter needs IP only)

--- a/uspecs/changes/2603271541-per-ip-rate-limit-scope/how.md
+++ b/uspecs/changes/2603271541-per-ip-rate-limit-scope/how.md
@@ -1,0 +1,34 @@
+# How: Use PER IP rate limit scope
+
+## Approach
+
+- Two fixes needed: `ResetLimits` missing `RateScope_IP` in bucket key construction, and all `IsLimitExceeded` callers passing empty `remoteAddr`
+- For `ResetLimits` in `pkg/appparts/internal/limiter/limiter.go` — add `remoteAddr string` parameter and set `key.RemoteAddr` when `RateScope_IP`, mirroring the existing logic in `Exceeded`
+- Propagate `remoteAddr` through the interface chain: `IAppPartition.ResetRateLimit` in `pkg/appparts/interface.go` gains `remoteAddr` parameter, implementation in `pkg/appparts/impl_app.go` forwards it
+- Source of `remoteAddr`: repurpose the existing `Host` field on `bus.Request` in `pkg/bus/types.go` to carry the client IP address (host only, port stripped). The router sets `Host: remoteIP(req.RemoteAddr)` in `pkg/router/utils.go` (`createBusRequest`), stripping the port via `net.SplitHostPort`. No separate `RemoteAddr` field is needed since `Host` was previously unused by the router
+- The `Host` field is already threaded through the VVM request handler into processor message constructors (`NewCommandMessage`, `NewQueryMessage`, `NewIQueryMessage`) and exposed via `Host()` accessors
+- Processor rate limit checks pass `msg.Host()` instead of `""`: `limitCallRate` in command processor, inline check in query v1 processor, `queryRateLimitExceeded` in query2
+- The verifier in `pkg/sys/verifier/impl.go` uses an anonymous interface cast for `ResetRateLimit` — update the interface signature to include `remoteAddr`
+- Update mocks in `pkg/processors/schedulers/impl_test.go` and test call sites in `pkg/processors/command/impl_test.go`
+
+**Investigation needed:**
+
+- `http.Request.RemoteAddr` contains `IP:port` — the port is stripped via `net.SplitHostPort` in the router before propagating to `bus.Request.RemoteAddr`. The value may still reflect a reverse proxy address rather than the real client IP
+- Consider whether headers like `X-Forwarded-For` or `X-Real-IP` should be preferred when a reverse proxy is in front of the router
+- Ensure the router extracts the correct value and propagates it via `bus.Request` to the VVM before processors use it for IP-scoped rate limiting
+
+References:
+
+- [pkg/appparts/internal/limiter/limiter.go](../../../pkg/appparts/internal/limiter/limiter.go)
+- [pkg/appparts/interface.go](../../../pkg/appparts/interface.go)
+- [pkg/appparts/impl_app.go](../../../pkg/appparts/impl_app.go)
+- [pkg/bus/types.go](../../../pkg/bus/types.go)
+- [pkg/router/utils.go](../../../pkg/router/utils.go)
+- [pkg/vvm/impl_requesthandler.go](../../../pkg/vvm/impl_requesthandler.go)
+- [pkg/processors/command/types.go](../../../pkg/processors/command/types.go)
+- [pkg/processors/command/impl.go](../../../pkg/processors/command/impl.go)
+- [pkg/processors/query/impl.go](../../../pkg/processors/query/impl.go)
+- [pkg/processors/query2/types.go](../../../pkg/processors/query2/types.go)
+- [pkg/processors/query2/util.go](../../../pkg/processors/query2/util.go)
+- [pkg/sys/verifier/impl.go](../../../pkg/sys/verifier/impl.go)
+

--- a/uspecs/changes/2603271541-per-ip-rate-limit-scope/impl.md
+++ b/uspecs/changes/2603271541-per-ip-rate-limit-scope/impl.md
@@ -1,0 +1,60 @@
+# Implementation plan: Use PER IP rate limit scope
+
+## Construction
+
+### Fix limiter `ResetLimits` to handle `RateScope_IP`
+
+- [x] update: [pkg/appparts/internal/limiter/limiter.go](../../../pkg/appparts/internal/limiter/limiter.go)
+  - update: Add `remoteAddr string` parameter to `ResetLimits` and set `key.RemoteAddr` when `RateScope_IP`, matching `Exceeded` logic
+- [x] update: [pkg/appparts/internal/limiter/example_test.go](../../../pkg/appparts/internal/limiter/example_test.go)
+  - update: Pass `remoteAddr` to `ResetLimits` in `Example_resetLimits`
+
+### Update `IAppPartition.ResetRateLimit` signature
+
+- [x] update: [pkg/appparts/interface.go](../../../pkg/appparts/interface.go)
+  - update: Add `remoteAddr string` parameter to `ResetRateLimit` in `IAppPartition`
+- [x] update: [pkg/appparts/impl_app.go](../../../pkg/appparts/impl_app.go)
+  - update: Pass `remoteAddr` from `borrowedPartition.ResetRateLimit` to `limiter.ResetLimits`
+
+### Populate `bus.Request.Host` with client IP in router
+
+- [x] update: [pkg/bus/types.go](../../../pkg/bus/types.go)
+  - update: `Host` field comment to describe it as client IP address (host only, port stripped)
+- [x] update: [pkg/router/utils.go](../../../pkg/router/utils.go)
+  - update: Set `bus.Request.Host` from `remoteIP(req.RemoteAddr)` in `createBusRequest`
+  - add: `remoteIP` helper function using `net.SplitHostPort` to strip port
+  - add: Host logging attribute in `withLogAttribs`
+
+### Use `Host()` for rate limiting in processors
+
+- [x] update: [pkg/processors/command/impl.go](../../../pkg/processors/command/impl.go)
+  - update: `limitCallRate` to pass `cmd.cmdMes.Host()` instead of empty string
+- [x] update: [pkg/processors/query/impl.go](../../../pkg/processors/query/impl.go)
+  - update: Rate limit check to pass `qw.msg.Host()` instead of empty string
+  - update: `ResetRateLimit` signature to include `remoteAddr string`
+- [x] update: [pkg/processors/query2/util.go](../../../pkg/processors/query2/util.go)
+  - update: `queryRateLimitExceeded` to pass `qw.msg.Host()` instead of empty string
+  - update: `ResetRateLimit` signature to include `remoteAddr string`
+
+### Update `ResetRateLimit` callers
+
+- [x] update: [pkg/sys/verifier/impl.go](../../../pkg/sys/verifier/impl.go)
+  - update: Anonymous `ResetRateLimit` interface cast and call to include `remoteAddr string` parameter
+
+### Update mocks
+
+- [x] update: [pkg/processors/schedulers/impl_test.go](../../../pkg/processors/schedulers/impl_test.go)
+  - update: Mock `ResetRateLimit` signature to include `remoteAddr string`
+- [x] Review
+
+### Integration test for PER IP rate limit
+
+- [x] update: [pkg/vit/schemaTestApp1.vsql](../../../pkg/vit/schemaTestApp1.vsql)
+  - add: `IPRatedCmd` command and `IPRatedQry` query declarations
+  - add: `RATE IPRatedPerMinute 2 PER MINUTE PER IP` and corresponding `LIMIT` declarations
+- [x] update: [pkg/vit/shared_cfgs.go](../../../pkg/vit/shared_cfgs.go)
+  - add: `QNameCmdIPRated` and `QNameQryIPRated` QName vars
+  - add: Builtin function registrations for `IPRatedCmd` and `IPRatedQry`
+- [x] update: [pkg/sys/it/impl_rates_test.go](../../../pkg/sys/it/impl_rates_test.go)
+  - add: `TestRates_PerIP` — verifies PER IP rate limits using `127.0.0.1` (localhost test requests)
+- [x] Review

--- a/uspecs/changes/2603271541-per-ip-rate-limit-scope/issue.md
+++ b/uspecs/changes/2603271541-per-ip-rate-limit-scope/issue.md
@@ -1,0 +1,22 @@
+# AIR-3420: Use PER IP rate limit scope
+
+**Source:** [AIR-3420](https://untill.atlassian.net/browse/AIR-3420)
+
+## Description
+
+There are two related problems with IP-scoped rate limiting:
+
+### 1. `ResetLimits` ignores `RateScope_IP`
+
+The `ResetLimits` method in `pkg/appparts/internal/limiter/limiter.go` does not use the `RateScope_IP` scope when constructing bucket keys. The `Exceeded` method correctly sets `key.RemoteAddr` when the rate has `RateScope_IP`, but `ResetLimits` omits this, leading to a mismatch in how rate limit buckets are identified and reset.
+
+This means when a rate limit with IP scope is reset, the reset targets a bucket key without the `RemoteAddr` field, which does not match the bucket key used during token consumption. As a result, IP-scoped rate limits are not effectively reset.
+
+### 2. `IsLimitExceeded` callers pass empty `remoteAddr`
+
+Both the command processor (`limitCallRate` in `pkg/processors/command/impl.go`) and the query processor (`check function call rate` in `pkg/processors/query/impl.go`) call `IsLimitExceeded` with an empty string `""` as `remoteAddr`. This means IP-scoped rate limits are never properly enforced — all requests share the same empty-address bucket instead of being tracked per IP.
+
+### Investigation needed
+
+It is necessary to investigate where the actual `remoteAddr` value should be sourced from in each call site (e.g., from the request message, HTTP headers, bus message metadata, etc.).
+


### PR DESCRIPTION
[AIR-3420](https://untill.atlassian.net/browse/AIR-3420) Fix PER IP rate limit scope handling

Add remoteAddr parameter to ResetLimits and propagate client IP through processors. Repurpose bus.Request.Host field for IP-based rate limiting with port stripping at router level.